### PR TITLE
Wrap passphrase in quotes for special characters

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -7,7 +7,7 @@ function attributes(cb, params) {
   const command = [
     'openssl pkcs12 -in',
     params.path,
-    '-nodes -passin pass:' + (params.password || '')
+    '-nodes -passin "pass:' + (params.password || '') + '"'
   ].join(' ');
 
   child_process.exec(command, (err, stdout) => {

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -8,7 +8,7 @@ function certificate(cb, params) {
     'openssl pkcs12 -in',
     params.path,
     '-nodes -clcerts -nokeys',
-    '-passin pass:' + (params.password || '')
+    '-passin "pass:' + (params.password || '') + '"'
   ].join(' ');
 
   child_process.exec(command, (err, stdout) => {

--- a/lib/key.js
+++ b/lib/key.js
@@ -8,7 +8,7 @@ function key(cb, params) {
     'openssl pkcs12 -in',
     params.path,
     '-nodes -nocerts ',
-    '-passin pass:' + (params.password || '')
+    '-passin "pass:' + (params.password || '') + '"'
   ].join(' ');
 
   child_process.exec(command, (err, stdout) => {


### PR DESCRIPTION
Passphrases may contain special characters (e.g. `&`). We should wrap `pass:my-passphrase` in quotes so that special characters are not interpreted by the shell.